### PR TITLE
Propogate failures for build jobs

### DIFF
--- a/vars/buildJob.groovy
+++ b/vars/buildJob.groovy
@@ -1,6 +1,5 @@
 def call(Map config = [:]){
     build(
-            //propagate: false,
             propagate: true,
             job: config.jobName,
             parameters: config.parameters

--- a/vars/buildJob.groovy
+++ b/vars/buildJob.groovy
@@ -1,6 +1,7 @@
 def call(Map config = [:]){
     build(
-            propagate: false,
+            //propagate: false,
+            propagate: true,
             job: config.jobName,
             parameters: config.parameters
     )


### PR DESCRIPTION
when the buildkob function is called any job failures should be propagated to the calling job