### PR TITLE
Repo tag function updates

### DIFF
--- a/vars/commitRepo.groovy
+++ b/vars/commitRepo.groovy
@@ -1,5 +1,6 @@
 def call(Map config) {
-    env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
+    //env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
+    env.GIT_TOKEN = "${config.gitToken}"
     env.GIT_REPO_URL = "${config.gitUrl}".replace('https://','')
     def targetDirectory = ""
     if ("${config.checkoutDirectory}" == "workspace"){

--- a/vars/tagRepo.groovy
+++ b/vars/tagRepo.groovy
@@ -1,5 +1,6 @@
 def call(Map config = [:]) {
-        env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
+        //env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
+        env.GIT_TOKEN = "${config.gitToken}"
         env.GIT_REPO_URL = "${config.gitUrl}".replace('https://','')
         def targetDirectory = ""
         if ("${config.checkoutDirectory}" == "workspace"){

--- a/vars/userCommitRepo.groovy
+++ b/vars/userCommitRepo.groovy
@@ -12,8 +12,8 @@ def call(Map config) {
         cd "${targetDirectory}"
         echo "Applying tag ${config.gitTag} to ${config.gitUrl}"
         git config --global push.followTags true
-        git config user.email "NCI-CTOS-DEVOPS-SVC@mail.nih.gov"
-        git config user.name "NCI-CTOS-DEVOPS-SVC"
+        git config user.email "vincent.donkor@gmail.com"
+        git config user.name "vdonkor"
         git add --all .
         git commit -am "tagging latest deployment.yaml"
         git push "https://${GIT_TOKEN}:x-oauth-basic@${GIT_REPO_URL}" HEAD:${params.Environment}

--- a/vars/userCommitRepo.groovy
+++ b/vars/userCommitRepo.groovy
@@ -1,6 +1,6 @@
 def call(Map config) {
     //env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
-    env.GIT_TOKEN = "${config.gitToken}"
+    env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
     env.GIT_REPO_URL = "${config.gitUrl}".replace('https://','')
     def targetDirectory = ""
     if ("${config.checkoutDirectory}" == "workspace"){

--- a/vars/userCommitRepo.groovy
+++ b/vars/userCommitRepo.groovy
@@ -1,0 +1,23 @@
+def call(Map config) {
+    //env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
+    env.GIT_TOKEN = "${config.gitToken}"
+    env.GIT_REPO_URL = "${config.gitUrl}".replace('https://','')
+    def targetDirectory = ""
+    if ("${config.checkoutDirectory}" == "workspace"){
+        targetDirectory = "."
+    }else{
+        targetDirectory = "${WORKSPACE}/${config.checkoutDirectory}"
+    }
+    sh """
+        cd "${targetDirectory}"
+        echo "Applying tag ${config.gitTag} to ${config.gitUrl}"
+        git config --global push.followTags true
+        git config user.email "NCI-CTOS-DEVOPS-SVC@mail.nih.gov"
+        git config user.name "NCI-CTOS-DEVOPS-SVC"
+        git add --all .
+        git commit -am "tagging latest deployment.yaml"
+        git push "https://${GIT_TOKEN}:x-oauth-basic@${GIT_REPO_URL}" HEAD:${params.Environment}
+        git tag --no-sign -a "${config.service}.${BUILD_NUMBER}" -m "Jenkins tag: ${config.service}.${BUILD_NUMBER}"
+        git push "https://${GIT_TOKEN}:x-oauth-basic@${GIT_REPO_URL}" --tags
+"""
+}

--- a/vars/userTagRepo.groovy
+++ b/vars/userTagRepo.groovy
@@ -1,6 +1,6 @@
 def call(Map config = [:]) {
         //env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
-        eenv.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
+        env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
         env.GIT_REPO_URL = "${config.gitUrl}".replace('https://','')
         def targetDirectory = ""
         if ("${config.checkoutDirectory}" == "workspace"){

--- a/vars/userTagRepo.groovy
+++ b/vars/userTagRepo.groovy
@@ -11,8 +11,8 @@ def call(Map config = [:]) {
         sh """
         cd "${targetDirectory}"
         echo "Applying tag ${config.gitTag} to ${config.gitUrl}"
-        git config user.email "NCI-CTOS-DEVOPS-SVC@mail.nih.gov "
-        git config user.name "NCI-CTOS-DEVOPS-SVC"
+        git config user.email "vincent.donkor@gmail.com"
+        git config user.name "vdonkor"
         git tag --no-sign -a "${config.gitTag}.${BUILD_NUMBER}" -m "Jenkins tag: ${config.gitTag}.${BUILD_NUMBER}"
         git push "https://${GIT_TOKEN}:x-oauth-basic@${GIT_REPO_URL}" --tags
 """

--- a/vars/userTagRepo.groovy
+++ b/vars/userTagRepo.groovy
@@ -1,6 +1,6 @@
 def call(Map config = [:]) {
         //env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
-        env.GIT_TOKEN = "${config.gitToken}"
+        eenv.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
         env.GIT_REPO_URL = "${config.gitUrl}".replace('https://','')
         def targetDirectory = ""
         if ("${config.checkoutDirectory}" == "workspace"){

--- a/vars/userTagRepo.groovy
+++ b/vars/userTagRepo.groovy
@@ -1,0 +1,19 @@
+def call(Map config = [:]) {
+        //env.GIT_TOKEN = sh(script: 'aws secretsmanager get-secret-value  --secret-id github/pat --region us-east-1 | jq --raw-output .SecretString | jq -r .token | tr -d \'\\n\'', returnStdout: true)
+        env.GIT_TOKEN = "${config.gitToken}"
+        env.GIT_REPO_URL = "${config.gitUrl}".replace('https://','')
+        def targetDirectory = ""
+        if ("${config.checkoutDirectory}" == "workspace"){
+                targetDirectory = "."
+        }else{
+                targetDirectory = "${WORKSPACE}/${config.checkoutDirectory}"
+        }
+        sh """
+        cd "${targetDirectory}"
+        echo "Applying tag ${config.gitTag} to ${config.gitUrl}"
+        git config user.email "NCI-CTOS-DEVOPS-SVC@mail.nih.gov "
+        git config user.name "NCI-CTOS-DEVOPS-SVC"
+        git tag --no-sign -a "${config.gitTag}.${BUILD_NUMBER}" -m "Jenkins tag: ${config.gitTag}.${BUILD_NUMBER}"
+        git push "https://${GIT_TOKEN}:x-oauth-basic@${GIT_REPO_URL}" --tags
+"""
+}

--- a/vars/writeDeployment.groovy
+++ b/vars/writeDeployment.groovy
@@ -25,6 +25,6 @@ def call(Map config = [:]){
         }
     }
     stage("update deployment repo"){
-        commitRepo service: config.service, gitTag: params["Environment"], gitUrl: config.deploymentRepoUrl, checkoutDirectory: config.deploymentCheckoutDirectory
+        userCommitRepo service: config.service, gitTag: params["Environment"], gitUrl: config.deploymentRepoUrl, checkoutDirectory: config.deploymentCheckoutDirectory
     }
 }


### PR DESCRIPTION
updated to allow the Git token to be passed directly into the functions for pushing tags to github. This will require a change in the jenkinsfiles to query the tokens from secrets manager before calling these functions as the queries will no longer be in the function. It will allow the use of secrets with different configurations to be used to hold the Git token.